### PR TITLE
Migrate from Google Gemini to OpenRouter API with Claude Sonnet 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 
 # DIY-Astra
 
-DIY-Astra is a Flask application that utilizes computer vision and natural language processing to create an interactive AI assistant. The application captures live video feed from a webcam, analyzes the captured images using the Google AI API, and generates text responses based on the visual input. The generated text responses are then converted to audio using the ElevenLabs API and played back to the user.
+DIY-Astra is a Flask application that utilizes computer vision and natural language processing to create an interactive AI assistant. The application captures live video feed from a webcam, analyzes the captured images using OpenRouter API (with Claude Sonnet 4), and generates text responses based on the visual input. The generated text responses are then converted to audio using the ElevenLabs API and played back to the user.
 
 ## Features
 - Live video feed capture from the webcam
-- Image analysis using the Google AI API
-- Text generation based on visual input
+- Image analysis using OpenRouter API with Claude Sonnet 4 (supports 400+ AI models)
+- Text generation based on visual input with context-aware conversation memory
 - Text-to-speech conversion using the ElevenLabs API
 - Real-time audio playback of generated responses
 - Web-based user interface for interaction and control
+- Flexible model selection (Claude Sonnet 4, Claude 3.5 Sonnet, Claude 3.7 Sonnet, and more)
 
 ## Requirements
 To run the DIY-Astra application, you need to have the following dependencies installed:
@@ -18,13 +19,12 @@ To run the DIY-Astra application, you need to have the following dependencies in
 - Flask-SocketIO
 - OpenCV (cv2)
 - Pydub
-- Google Generative AI Client Library
 - Pillow (PIL)
 - Requests
 
 You also need to have valid API keys for the following services:
-- Google AI API (GOOGLE_API_KEY)
-- ElevenLabs API (ELEVENLABS_API_KEY)
+- OpenRouter API (OPENROUTER_API_KEY) - Get your free key at https://openrouter.ai/keys
+- ElevenLabs API (ELEVENLABS_API_KEY) - For text-to-speech conversion
 
 ## Installation
 1. Clone the repository:
@@ -43,8 +43,13 @@ You also need to have valid API keys for the following services:
    ```
 
 4. Set up the API keys:
-   - Replace `GOOGLE_API_KEY` in `app.py` with your Google AI API key.
+   - Replace `OPENROUTER_API_KEY` in `app.py` with your OpenRouter API key.
    - Replace `ELEVENLABS_API_KEY` in `app.py` with your ElevenLabs API key.
+   - (Optional) Change `MODEL_NAME` to use different AI models like:
+     - `anthropic/claude-sonnet-4` (default, most capable)
+     - `anthropic/claude-3.5-sonnet` (faster, cheaper)
+     - `anthropic/claude-3.7-sonnet` (balanced)
+     - Or any other vision-capable model from OpenRouter's 400+ models
 
 5. Run the application:
    ```bash
@@ -58,10 +63,11 @@ You also need to have valid API keys for the following services:
 2. Launch the DIY-Astra application by running `python app.py`.
 3. The application will open in your default web browser.
 4. The live video feed from your webcam will be displayed in the interface.
-5. DIY-Astra will continuously capture images, analyze them using the Google AI API, and generate text responses based on the visual input.
+5. DIY-Astra will continuously capture images, analyze them using OpenRouter API (Claude Sonnet 4), and generate text responses based on the visual input.
 6. The generated text responses will be displayed in the text container below the video feed.
 7. The text responses will also be converted to audio using the ElevenLabs API and played back in real-time.
 8. You can stop the application by clicking the "Stop" button in the interface. To resume, click the "Resume" button.
+9. Adjust the capture interval (in seconds) to control how frequently Astra analyzes new images.
 
 ## File Structure
 - `app.py`: The main Flask application file containing the server-side logic.

--- a/app.py
+++ b/app.py
@@ -4,12 +4,11 @@ import threading
 import base64
 import time
 import requests
-from flask import Flask, render_template, jsonify
+from flask import Flask, render_template, jsonify, request
 from flask_socketio import SocketIO, emit
 from queue import Queue
 from pydub import AudioSegment
 from pydub.playback import play
-import google.generativeai as genai
 from PIL import Image
 import numpy as np
 import errno
@@ -18,15 +17,16 @@ import errno
 app = Flask(__name__)
 socketio = SocketIO(app, cors_allowed_origins='*')
 
-# Set the API keys for Google AI and ElevenLabs
-GOOGLE_API_KEY = 'YOUR KEY HERE'
+# Set the API keys for OpenRouter and ElevenLabs
+OPENROUTER_API_KEY = 'YOUR KEY HERE'
 ELEVENLABS_API_KEY = 'YOUR KEY HERE'
 # Voice ID for ElevenLabs API (I using a standard voice but make sure you have access to it)
 VOICE_ID = 'lNHyfbhlVgOTtlbts3eH'
 
-# Configure the Google AI client
-genai.configure(api_key=GOOGLE_API_KEY)
-model = genai.GenerativeModel('models/gemini-1.5-flash-latest')
+# Configure OpenRouter API
+OPENROUTER_API_URL = "https://openrouter.ai/api/v1/chat/completions"
+# Model options: anthropic/claude-sonnet-4, anthropic/claude-3.5-sonnet, anthropic/claude-3.7-sonnet
+MODEL_NAME = "anthropic/claude-sonnet-4"
 
 # Folder to save frames
 folder = "frames"
@@ -108,42 +108,60 @@ def play_audio():
             audio_playing.clear()
 
 def generate_new_line(encoded_image):
-    return [
-        {
-            "role": "user",
-            "content": {
-                "parts": [
-                    {
-                        "text": "Please describe what you see in max 30 words. You are an helpful and friendly assistant called Astra. If you see questions visually answer them is very important! "
-                    },
-                    {
-                        "inline_data": {
-                            "mime_type": "image/jpeg",
-                            "data": encoded_image
-                        }
-                    }
-                ]
+    """Generate a new message with image for OpenRouter API"""
+    return {
+        "role": "user",
+        "content": [
+            {
+                "type": "text",
+                "text": "Please describe what you see in max 30 words. You are a helpful and friendly assistant called Astra. If you see questions visually answer them - this is very important!"
+            },
+            {
+                "type": "image_url",
+                "image_url": {
+                    "url": f"data:image/jpeg;base64,{encoded_image}"
+                }
             }
-        }
-    ]
+        ]
+    }
 
 def analyze_image(encoded_image, script):
+    """Send image to OpenRouter API (Claude) for analysis"""
     try:
-        messages = script + generate_new_line(encoded_image)
-        content_messages = [
-            {
-                "role": message["role"],
-                "parts": [
-                    {"text": part["text"]} if "text" in part else {"inline_data": part["inline_data"]}
-                    for part in message["content"]["parts"]
-                ]
-            }
-            for message in messages
-        ]
-        response = model.generate_content(content_messages)
-        return response.text
+        # Build messages array - convert script + new message
+        messages = script + [generate_new_line(encoded_image)]
+
+        # Prepare headers
+        headers = {
+            "Authorization": f"Bearer {OPENROUTER_API_KEY}",
+            "Content-Type": "application/json",
+            "HTTP-Referer": "http://localhost:5001",  # Optional, for rankings
+            "X-Title": "DIY-Astra"  # Optional, shows in rankings
+        }
+
+        # Prepare request payload
+        payload = {
+            "model": MODEL_NAME,
+            "messages": messages
+        }
+
+        # Make API request
+        response = requests.post(
+            OPENROUTER_API_URL,
+            headers=headers,
+            json=payload,
+            timeout=30
+        )
+        response.raise_for_status()
+
+        # Extract response text
+        result = response.json()
+        return result['choices'][0]['message']['content']
+
     except Exception as e:
         print(f"Error in analyze_image: {e}")
+        if hasattr(e, 'response') and e.response is not None:
+            print(f"Response content: {e.response.text}")
         return ""
 
 def capture_images():
@@ -185,16 +203,11 @@ def capture_images():
 
                 text_queue.put(response_text)
                 socketio.emit('text', {'message': response_text})
+                # Add assistant's response to conversation history (OpenAI format)
                 script.append(
                     {
-                        "role": "model",
-                        "content": {
-                            "parts": [
-                                {
-                                    "text": response_text
-                                }
-                            ]
-                        }
+                        "role": "assistant",
+                        "content": response_text
                     }
                 )
             else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,5 @@ flask
 flask-socketio
 opencv-python
 pydub
-google-generativeai
 pillow
 requests


### PR DESCRIPTION
Major changes:
- Replaced Google Generative AI with OpenRouter API
- Configured to use Claude Sonnet 4 (anthropic/claude-sonnet-4)
- Updated to OpenAI-compatible message format for multimodal vision
- Added support for 400+ AI models via OpenRouter
- Fixed missing 'request' import for set_interval endpoint
- Updated requirements.txt (removed google-generativeai)
- Updated README.md with OpenRouter setup instructions
- Improved conversation history format (assistant role)
- Added better error handling with response logging

Benefits:
- Access to Claude Sonnet 4 (most capable vision model)
- Flexibility to switch between models easily
- OpenAI-compatible API format
- More cost-effective options available

🤖 Generated with [Claude Code](https://claude.com/claude-code)